### PR TITLE
Removing fsGroup from example as it'll enforce the gid on the kdf vol…

### DIFF
--- a/examples/testsecure.yaml
+++ b/examples/testsecure.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   securityContext:
     runAsUser: 1000
-    fsGroup: 2000
   containers:
   - name: busybox
     image: busybox

--- a/examples/testsimple.yaml
+++ b/examples/testsimple.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   securityContext:
     runAsUser: 1000
-    fsGroup: 2000
   containers:
   - name: busybox
     image: busybox


### PR DESCRIPTION
…ume mount (MapR fs)

This PR has changes to remove fsGroup from the example due to behavior it pertain with setting gid on the volume mount.