### PR TITLE
KDF plugin 1.0.2 release changes 

### DIFF
--- a/build/plugincentos/Dockerfile
+++ b/build/plugincentos/Dockerfile
@@ -27,14 +27,14 @@ RUN rpm --import http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7; \
 WORKDIR /tmp
 
 # Main Docker Build
-RUN wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/redhat/mapr-client-6.0.1.20180404222005.GA-1.x86_64.rpm; \
+RUN wget wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.2/redhat/mapr-client-6.0.1.20180710151556.GA-20180710151556.x86_64.rpm; \
     wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/redhat/mapr-librdkafka-0.11.3.201803231414-1.noarch.rpm; \
-    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/redhat/mapr-posix-client-basic-6.0.1.20180404222005.GA-1.x86_64.rpm; \
-    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/redhat/mapr-posix-client-platinum-6.0.1.20180404222005.GA-1.x86_64.rpm; \
+    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.2/redhat/mapr-posix-client-basic-6.0.1.20180710151556.GA-1.x86_64.rpm; \
+    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.2/redhat/mapr-posix-client-platinum-6.0.1.20180710151556.GA-1.x86_64.rpm; \
     rpm -Uvh mapr-librdkafka-0.11.3.201803231414-1.noarch.rpm; \
-    rpm -Uvh mapr-client-6.0.1.20180404222005.GA-1.x86_64.rpm; \
-    rpm -Uvh mapr-posix-client-basic-6.0.1.20180404222005.GA-1.x86_64.rpm; \
-    rpm -Uvh mapr-posix-client-platinum-6.0.1.20180404222005.GA-1.x86_64.rpm; \
+    rpm -Uvh mapr-client-6.0.1.20180710151556.GA-20180710151556.x86_64.rpm; \
+    rpm -Uvh mapr-posix-client-basic-6.0.1.20180710151556.GA-1.x86_64.rpm; \
+    rpm -Uvh mapr-posix-client-platinum-6.0.1.20180710151556.GA-1.x86_64.rpm; \
     mkdir -p /tmp/lib; \
     cp -r /opt/mapr/lib/libfuse.* /tmp/lib; \
     cp -r /opt/mapr/lib/libMapRClient_c.* /tmp/lib; \

--- a/build/plugincentos/docker-build.sh
+++ b/build/plugincentos/docker-build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build --force-rm --pull -t maprtech/kdf-plugin:1.0.1_001_centos7 .
+docker build --force-rm --pull -t maprtech/kdf-plugin:1.0.2_001_centos7 .

--- a/build/plugincentos/maprfs/main.go
+++ b/build/plugincentos/maprfs/main.go
@@ -468,7 +468,7 @@ func doInit() {
 		}
 	}
 	Plugin.Println("INFO  === Finished init of MapRfs Plugin ===")
-	fmt.Print(" { \"status\": \"Success\" , \"capabilities\": {\"attach\": false } } ")
+	fmt.Print(" { \"status\": \"Success\" , \"capabilities\": {\"attach\": false, \"selinuxRelabel\": false } } ")
 	os.Exit(0)
 }
 

--- a/build/pluginubuntu/Dockerfile
+++ b/build/pluginubuntu/Dockerfile
@@ -21,14 +21,14 @@ RUN apt-get update; \
     apt-get install -y apt-utils sudo lsb-release; \
     DEBIAN_FRONTEND=noninteractive apt-get install --allow-unauthenticated -y wget perl syslinux openjdk-8-jdk
 # Install MapR packages
-RUN wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/ubuntu/mapr-client-6.0.1.20180404222005.GA-1.amd64.deb; \
+RUN wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.2/ubuntu/mapr-client-6.0.1.20180710151556.GA-20180710151556.amd64.deb; \
     wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/ubuntu/mapr-librdkafka_0.11.3.201803231414_all.deb; \
-    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/ubuntu/mapr-posix-client-basic_6.0.1.20180404222005.GA-1_amd64.deb; \
-    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.1/ubuntu/mapr-posix-client-platinum_6.0.1.20180404222005.GA-1_amd64.deb; \
+    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.2/ubuntu/mapr-posix-client-basic_6.0.1.20180710151556.GA-20180710151556_amd64.deb; \
+    wget http://package.mapr.com/tools/KubernetesDataFabric/v1.0.2/ubuntu/mapr-posix-client-platinum_6.0.1.20180710151556.GA-20180710151556_amd64.deb; \
     dpkg -i --force-overwrite /tmp/mapr-librdkafka_0.11.3.201803231414_all.deb; \
-    dpkg -i --force-overwrite /tmp/mapr-client-6.0.1.20180404222005.GA-1.amd64.deb; \
-    dpkg -i --force-overwrite /tmp/mapr-posix-client-basic_6.0.1.20180404222005.GA-1_amd64.deb; \
-    dpkg -i --force-overwrite /tmp/mapr-posix-client-platinum_6.0.1.20180404222005.GA-1_amd64.deb; \
+    dpkg -i --force-overwrite /tmp/mapr-client-6.0.1.20180710151556.GA-20180710151556.amd64.deb; \
+    dpkg -i --force-overwrite /tmp/mapr-posix-client-basic_6.0.1.20180710151556.GA-20180710151556_amd64.deb; \
+    dpkg -i --force-overwrite /tmp/mapr-posix-client-platinum_6.0.1.20180710151556.GA-20180710151556_amd64.deb; \
     mkdir -p /tmp/lib; \
     cp -r /opt/mapr/lib/libfuse.* /tmp/lib; \
     cp -r /opt/mapr/lib/libMapRClient_c.* /tmp/lib; \

--- a/build/pluginubuntu/docker-build.sh
+++ b/build/pluginubuntu/docker-build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build --force-rm --pull -t maprtech/kdf-plugin:1.0.1_001_ubuntu .
+docker build --force-rm --pull -t maprtech/kdf-plugin:1.0.2_001_ubuntu .

--- a/build/pluginubuntu/maprfs/main.go
+++ b/build/pluginubuntu/maprfs/main.go
@@ -468,7 +468,7 @@ func doInit() {
 		}
 	}
 	Plugin.Println("INFO  === Finished init of MapRfs Plugin ===")
-	fmt.Print(" { \"status\": \"Success\" , \"capabilities\": {\"attach\": false } } ")
+	fmt.Print(" { \"status\": \"Success\" , \"capabilities\": {\"attach\": false, \"selinuxRelabel\": false } } ")
 	os.Exit(0)
 }
 

--- a/deploy/kdf-plugin-azure.yaml
+++ b/deploy/kdf-plugin-azure.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: mapr-kdfplugin
           imagePullPolicy: Always
-          image: maprtech/kdf-plugin:1.0.1_001_ubuntu
+          image: maprtech/kdf-plugin:1.0.2_001_ubuntu
           command:
           - bash
           - -c

--- a/deploy/kdf-plugin-centos.yaml
+++ b/deploy/kdf-plugin-centos.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: mapr-kdfplugin
           imagePullPolicy: Always
-          image: maprtech/kdf-plugin:1.0.1_001_centos7
+          image: maprtech/kdf-plugin:1.0.2_001_centos7
           command:
           - bash
           - -c

--- a/deploy/kdf-plugin-gke.yaml
+++ b/deploy/kdf-plugin-gke.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: mapr-kdfplugin
           imagePullPolicy: Always
-          image: maprtech/kdf-plugin:1.0.1_001_ubuntu
+          image: maprtech/kdf-plugin:1.0.2_001_ubuntu
           command:
           - bash
           - -c

--- a/deploy/kdf-plugin-openshift.yaml
+++ b/deploy/kdf-plugin-openshift.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: mapr-kdfplugin
           imagePullPolicy: Always
-          image: maprtech/kdf-plugin:1.0.1_001_centos7
+          image: maprtech/kdf-plugin:1.0.2_001_centos7
           command:
           - bash
           - -c

--- a/deploy/kdf-plugin-ubuntu.yaml
+++ b/deploy/kdf-plugin-ubuntu.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: mapr-kdfplugin
           imagePullPolicy: Always
-          image: maprtech/kdf-plugin:1.0.1_001_ubuntu
+          image: maprtech/kdf-plugin:1.0.2_001_ubuntu
           command:
           - bash
           - -c


### PR DESCRIPTION
This PR has changes mandated for 1.0.2 version release. 

This includes:
1. The posix client packages are updated to 6.0.1-EBF build updated till (July 10, 2018).
2. Set selinuxRelaebl to false for volume plugin init() call
3. New images tag for released plugin 1.0.2 release